### PR TITLE
Completed the Maintenance-StageTypes page by adding a colored chip to…

### DIFF
--- a/Amusing/Amusing.csproj
+++ b/Amusing/Amusing.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-Amusing-d4b4dda8-27a3-4a96-94e4-f605690b8606</UserSecretsId>
-    <AssemblyVersion>25.7.31.27</AssemblyVersion>
-    <FileVersion>25.7.31.27</FileVersion>
+    <AssemblyVersion>25.8.4.4</AssemblyVersion>
+    <FileVersion>25.8.4.4</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Amusing/Components/Pages/Maintenance-StageTypes.razor
+++ b/Amusing/Components/Pages/Maintenance-StageTypes.razor
@@ -124,7 +124,22 @@ else
                 <GridColumn Field="Description" HeaderText="Omvat" TextAlign="TextAlign.Left" AllowSorting=true AllowResizing="true" />
                 <GridColumn Field="Price" HeaderText="Prijs" Format="C2" TextAlign="TextAlign.Center" AllowSorting=true AllowResizing="true" Width="90px" />
                 <GridColumn Field="Compatibel" HeaderText="Compatibel met" TextAlign="TextAlign.Left" AllowSorting=false AllowResizing="true" Width="135px" />
-                <GridColumn Field="Active" HeaderText="Aktive" TextAlign="TextAlign.Center" AllowSorting=true AllowResizing="true" Width="80px" />
+                <GridColumn Field="Active" HeaderText="Aktief" TextAlign="TextAlign.Center" Width="120px">
+                    <Template>
+                        @{
+                            var stage = (context as StageTypeModel);
+                            var activeState = stage.Active == 1 ? "Aktief" : "Niet aktief";
+                            var activeStateColor = stage.Active == 1 ? "e-success" : "e-danger";
+                            <div class="template_checkbox">
+                                <SfChip id="chip">
+                                    <ChipItems>
+                                        <ChipItem Text="@activeState" CssClass="@($"{activeStateColor} custom-chip")" Width="120px"/>
+                                    </ChipItems>
+                                </SfChip>
+                            </div>
+                        }
+                    </Template>
+                </GridColumn>
             </GridColumns>
         </SfGrid>
         <div class="spacer-large"></div>

--- a/Amusing/wwwroot/css/app.css
+++ b/Amusing/wwwroot/css/app.css
@@ -317,3 +317,15 @@ a, .btn-link {
     border-color: green;
     background-color: green;
 }
+
+/* chip settings*/
+.custom-chip.e-chip {
+    width: 100px !important;
+    justify-content: center !important;
+    text-align: center !important;
+    white-space: nowrap !important;
+    overflow: hidden;
+    padding: 4px 0 !important;
+    font-weight: bold !important;
+    font-size: 12px !important;
+}


### PR DESCRIPTION
… the datagrid to show active and inactive podium types.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `Maintenance-StageTypes` page to include a colored chip indicating the active state of stage types.

### Why are these changes being made?

The change visually differentiates active and inactive stage types using color-coded chips for improved user interface clarity and user experience. This approach enhances the readability and quick identification of the stage's status directly from the grid view, utilizing a simple and visually appealing design element.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->