### PR TITLE
Changed the way update visible rowncount was implemented because on a…

### DIFF
--- a/Amusing/Components/Pages/ListFestivals.razor.cs
+++ b/Amusing/Components/Pages/ListFestivals.razor.cs
@@ -24,12 +24,26 @@ public partial class ListFestivals : ComponentBase
     protected int VisibleRowCount = 0;
     protected List<FestivalModel> Festivals = [];
     protected string FileName = "Festivals";
+    private bool _hasRendered = false;
 
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
         Festivals = await FestivalService.GetFestivalOverviewAsync();
         IsLoading = false;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hasRendered = true;
+
+            if (Festivals?.Count > 0)
+            {
+                await UpdateVisibleRowCountAsync();
+            }
+        }
     }
 
     // Manage direct search functionality
@@ -43,15 +57,15 @@ public partial class ListFestivals : ComponentBase
 
     protected async Task UpdateVisibleRowCountAsync()
     {
-        if ( GridRef is not null )
-        {
-            await GridRef.Refresh();
-            await Task.Delay( 50 );
-            var records = await GridRef.GetCurrentViewRecordsAsync();
-            await Task.Delay( 150 );
-            VisibleRowCount = records?.Count ?? 0;
-            StateHasChanged();
-        }
+        if (GridRef == null)
+            return;
+
+        await GridRef.Refresh();
+        await Task.Delay( 50 );
+        var records = await GridRef.GetCurrentViewRecordsAsync();
+        await Task.Delay( 150 );
+        VisibleRowCount = records?.Count ?? 0;
+        StateHasChanged();
     }
 
     protected async Task OnGridDataBound()

--- a/Amusing/Components/Pages/ListGroups.razor.cs
+++ b/Amusing/Components/Pages/ListGroups.razor.cs
@@ -28,6 +28,7 @@ public partial class ListGroups : ComponentBase
     protected int VisibleRowCount = 0;
     protected List<FestivalParticipationDynamicViewModel> Zanggroepen = [];
     protected List<int> YearColumns = [];
+    private bool _hasRendered = false;
 
     protected int FilterOnFestival;
 
@@ -77,6 +78,19 @@ public partial class ListGroups : ComponentBase
         FilterOnFestival = await RegistrationService.GetCurrentFestivalYearAsync() - 3; // This Value should be equal to NumberOfYearsForExclusion in QueryDefinitions.GetFestivalOverviewQuery
 
         await LoadDataAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hasRendered = true;
+
+            if (Zanggroepen?.Count > 0)
+            {
+                await UpdateVisibleRowCountAsync();
+            }
+        }
     }
 
     protected async Task LoadDataAsync()
@@ -189,6 +203,9 @@ public partial class ListGroups : ComponentBase
 
     protected async Task UpdateVisibleRowCountAsync()
     {
+        if (GridRef == null)
+            return;
+
         var records = await GridRef.GetCurrentViewRecordsAsync();
         VisibleRowCount = records?.Count ?? 0;
         StateHasChanged();

--- a/Amusing/Components/Pages/ListStageTypes.razor.cs
+++ b/Amusing/Components/Pages/ListStageTypes.razor.cs
@@ -24,12 +24,26 @@ public partial class ListStageTypes : ComponentBase
     protected int VisibleRowCount = 0;
     protected List<StageTypeModel> StageTypes = [];
     protected string FileName = "Podium types";
+    private bool _hasRendered = false;
 
     protected override async Task OnInitializedAsync()
     {
         IsLoading = true;
         StageTypes = await StageTypeService.GetStageTypesAsync();
         IsLoading = false;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hasRendered = true;
+
+            if (StageTypes?.Count > 0)
+            {
+                await UpdateVisibleRowCountAsync();
+            }
+        }
     }
 
     // Manage direct search functionality
@@ -43,15 +57,15 @@ public partial class ListStageTypes : ComponentBase
 
     protected async Task UpdateVisibleRowCountAsync()
     {
-        if ( GridRef is not null )
-        {
-            await GridRef.Refresh();
+        if (GridRef == null)
+            return;
+
+        await GridRef.Refresh();
             await Task.Delay( 50 );
             var records = await GridRef.GetCurrentViewRecordsAsync();
             await Task.Delay( 150 );
             VisibleRowCount = records?.Count ?? 0;
             StateHasChanged();
-        }
     }
 
     protected async Task OnGridDataBound()

--- a/Amusing/Components/Pages/MaintenanceSubscriptions.razor.cs
+++ b/Amusing/Components/Pages/MaintenanceSubscriptions.razor.cs
@@ -22,6 +22,7 @@ public partial class MaintenanceSubscriptions : ComponentBase
     protected int VisibleRowCount = 0;
     private uint editingPaymentId;
     private bool showPaymentDialog;
+    private bool _hasRendered = false;
 
     private bool showDatePicker { get; set; }
     private DateTime? selectedDate { get; set; }
@@ -43,6 +44,19 @@ public partial class MaintenanceSubscriptions : ComponentBase
             // Get the registrations for the selected edition
             RegistrationList = await RegistrationService.GetRegistrationsByFestivalIdAsync( Convert.ToUInt32( SelectedEditionId ) );
             if ( SelectedEditionId != null && RegistrationList.Count > 0 )
+            {
+                await UpdateVisibleRowCount();
+            }
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hasRendered = true;
+
+            if (Editions?.Count > 0)
             {
                 await UpdateVisibleRowCount();
             }
@@ -88,6 +102,9 @@ public partial class MaintenanceSubscriptions : ComponentBase
 
     protected async Task UpdateVisibleRowCount()
     {
+        if (GridRef == null)
+            return;
+
         var data = await GridRef.GetCurrentViewRecordsAsync();
         VisibleRowCount = data?.Count ?? 0;
     }

--- a/Amusing/Components/Pages/OverviewRegistrations.razor.cs
+++ b/Amusing/Components/Pages/OverviewRegistrations.razor.cs
@@ -24,6 +24,7 @@ public partial class OverviewRegistrations : ComponentBase
     protected List<RegistrationModel> RegistrationList = [];
     protected string? SelectedEditionId;
     protected int VisibleRowCount = 0;
+    private bool _hasRendered = false;
 
     protected string SelectedEditionText => Editions.FirstOrDefault( e => e.ID == SelectedEditionId )?.Text ?? "Onbekende editie";
 
@@ -41,6 +42,19 @@ public partial class OverviewRegistrations : ComponentBase
             // Get the registrations for the selected edition
             RegistrationList = await RegistrationService.GetRegistrationsByFestivalIdAsync( Convert.ToUInt32( SelectedEditionId ) );
             if ( SelectedEditionId != null && RegistrationList.Count > 0 )
+            {
+                await UpdateVisibleRowCount();
+            }
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hasRendered = true;
+
+            if (RegistrationList?.Count > 0)
             {
                 await UpdateVisibleRowCount();
             }
@@ -127,6 +141,9 @@ public partial class OverviewRegistrations : ComponentBase
     // Visible row count (Number of records on screen)
     protected async Task UpdateVisibleRowCount()
     {
+        if (GridRef == null)
+            return;
+        
         var data = await GridRef.GetCurrentViewRecordsAsync();
         VisibleRowCount = data?.Count ?? 0;
     }


### PR DESCRIPTION
… few pages the grid was not completely rendered when the rowcount started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grid display across multiple list pages to properly calculate and display row counts after the initial page load for festivals, groups, stage types, subscriptions, and registrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->